### PR TITLE
Add test and release workflows to build multi-arch Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+env:
+  IMAGE: zappi/k8s-ttl-controller
+
+jobs:
+  github:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Version ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+  docker-hub:
+    needs: github
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: TwiN/k8s-ttl-controller
+          ref: "v${{ github.ref_name }}"
+      - name: Prepare Image Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+      - name: Set Up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set Up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login To Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Build, tag, and push image to Docker Hub
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          annotations: ${{ steps.metadata.outputs.annotations }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}
+
+  docker-hub-description:
+    needs: docker-hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Update Description On Docker Hub Description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  # Update this to the exact version that you want to test i.e. the packaging
+  # into a Docker image.
+  VERSION: 1.3.1
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: zappi/k8s-ttl-controller
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: TwiN/k8s-ttl-controller
+          ref: v${{ env.VERSION }}
+      - name: Prepare Image Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+      - name: Set Up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set Up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Test Multi-Arch Building Of Image
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          annotations: ${{ steps.metadata.outputs.annotations }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Intellection/SRE

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Intellection
+Copyright (c) 2024 Zappi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# docker-k8s-ttl-controller
+
+[![release](https://github.com/Intellection/docker-k8s-ttl-controller/actions/workflows/release.yml/badge.svg)](https://github.com/Intellection/docker-k8s-ttl-controller/actions/workflows/release.yml) [![test](https://github.com/Intellection/docker-k8s-ttl-controller/actions/workflows/test.yml/badge.svg)](https://github.com/Intellection/docker-k8s-ttl-controller/actions/workflows/test.yml)
+
+Docker image for [`TwiN/k8s-ttl-controller`](https://github.com/TwiN/k8s-ttl-controller), a Kubernetes controller that enables timed resource deletion using TTL annotation.
+
+## Motivations
+
+### How does this differ from upstream?
+
+The current Docker image doesn't support ARM and we needed one that does. And [the review to add support](https://github.com/TwiN/k8s-ttl-controller/pull/95) took longer than we could wait.
+
+## Usage
+
+```
+docker run --name k8s-ttl-controller zappi/k8s-ttl-controller:latest
+```
+
+For more detailed usage documentation [see upstream](https://github.com/TwiN/k8s-ttl-controller).


### PR DESCRIPTION
Pretty much packages the upstream `k8s-ttl-controller` as a multi-arch Docker image supporting AMD64 and ARM64. The current Docker image doesn't support ARM and we needed one that does. And https://github.com/TwiN/k8s-ttl-controller/pull/95 took longer than we could wait.

It's worth noting that the build takes a while at [this step in the upstream's `Dockerfile`](https://github.com/TwiN/k8s-ttl-controller/blob/054dde727e7d53d32235658ad5a36809d7bac5a9/Dockerfile#L5) ...

```dockerfile
RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o k8s-ttl-controller .
```

I suspect it's because of all the instructions to ensure there's no dynamic linking and using alpine 🤷🏽‍♂️ i.e.

- `CGO_ENABLED=0` - Disables CGO ensuring the binary is statically compiled for better portability
- `GOOS=linux` - Sets target OS making sure the binary is compiled for Linux
- `-a -installsuffix cgo` - Forces a full rebuild of packages and ensures no dynamic linking with C libraries

### References

* https://hub.docker.com/repository/docker/zappi/k8s-ttl-controller

### Related

* https://github.com/TwiN/k8s-ttl-controller/pull/95